### PR TITLE
Sync code with m-c

### DIFF
--- a/extension/api.js
+++ b/extension/api.js
@@ -1,9 +1,12 @@
-const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-const { XPCOMUtils } = ChromeUtils.import(
-  "resource://gre/modules/XPCOMUtils.jsm"
-);
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/* globals ExtensionAPI, Services, XPCOMUtils, WebExtensionPolicy */
+
 XPCOMUtils.defineLazyGlobalGetters(this, ["ChannelWrapper"]);
-const { WebExtensionPolicy } = Cu.getGlobalForObject(Services);
 
 XPCOMUtils.defineLazyServiceGetter(
   this,
@@ -20,7 +23,8 @@ XPCOMUtils.defineLazyServiceGetter(
 
 XPCOMUtils.defineLazyModuleGetters(this, {
   ExtensionParent: "resource://gre/modules/ExtensionParent.jsm",
-  ExtensionPreferencesManager: "resource://gre/modules/ExtensionPreferencesManager.jsm",
+  ExtensionPreferencesManager:
+    "resource://gre/modules/ExtensionPreferencesManager.jsm",
 });
 
 XPCOMUtils.defineLazyGetter(
@@ -35,7 +39,8 @@ const MAX_DISABLED_PI = 2;
 const PREF_MONITOR_DATA = "extensions.proxyMonitor.state";
 const PREF_MONITOR_LOGGING = "extensions.proxyMonitor.logging.enabled";
 const PREF_PROXY_FAILOVER = "network.proxy.failover_direct";
-const CHECK_EXTENSION_ONLY = Services.vc.compare(Services.appinfo.version, "92.0") >= 0
+const CHECK_EXTENSION_ONLY =
+  Services.vc.compare(Services.appinfo.version, "92.0") >= 0;
 
 const PROXY_CONFIG_TYPES = [
   "direct",
@@ -43,12 +48,12 @@ const PROXY_CONFIG_TYPES = [
   "pac",
   "unused", // nsIProtocolProxyService.idl skips index 3.
   "wpad",
-  "system"
+  "system",
 ];
 
 function hoursSince(dt2, dt1 = Date.now()) {
   var diff = (dt2 - dt1) / 1000;
-  diff /= (60 * 60);
+  diff /= 60 * 60;
   return Math.abs(Math.round(diff));
 }
 
@@ -60,33 +65,35 @@ function log(msg) {
 }
 
 /**
- * ProxyMonitor monitors system and protected requests for failures
- * due to bad or unavailable proxy configurations.
- * 
- * In a system with multiple layers of proxy configuration, if there is a 
- * failing proxy we try to remove just that confuration from the chain.  However if 
- * we get too many failures, we'll make a direct connection the top "proxy".
- * 
+ * ProxyMonitor monitors system and protected requests for failures due to bad
+ * or unavailable proxy configurations.
+ *
+ * In a system with multiple layers of proxy configuration, if there is a
+ * failing proxy we try to remove just that confuration from the chain.
+ * However if we get too many failures, we'll make a direct connection the top
+ * "proxy".
+ *
  * 1. Any proxied system request without a direct failover will have one added.
- * 
- * 2. If a proxied system request fails, the proxy configuration in use will
- * be disabled.  On later requests, disabled proxies are removed from the proxy chain.
- * Disabled proxy configurations remain disabled for 48 hours to allow any necessary
- * requests to operate for a period of time. When disabled proxies are used as a
- * failover to a direct request (step 3 or 4 below), the proxy can be detected
- * as functional and be re-enabled despite not having reached the 48 hours.
- * 
- * 3. If too many proxy configurations got disabled, we make a direct config first
- * with failover to all other proxy configurations (essentially skipping step 2).
- * This state remains for 48 hours before retrying without "direct".
- * 
- * 4. If we've removed all proxies we make a direct config first and failover to 
- * the other proxy configurations, similar to step 3.
- * 
+ *
+ * 2. If a proxied system request fails, the proxy configuration in use will be
+ * disabled.  On later requests, disabled proxies are removed from the proxy
+ * chain.  Disabled proxy configurations remain disabled for 48 hours to allow
+ * any necessary requests to operate for a period of time. When disabled
+ * proxies are used as a failover to a direct request (step 3 or 4 below), the
+ * proxy can be detected as functional and be re-enabled despite not having
+ * reached the 48 hours.
+ *
+ * 3. If too many proxy configurations got disabled, we make a direct config
+ * first with failover to all other proxy configurations (essentially skipping
+ * step 2).  This state remains for 48 hours before retrying without "direct".
+ *
+ * 4. If we've removed all proxies we make a direct config first and failover
+ * to the other proxy configurations, similar to step 3.
+ *
  * 5. Starting with Fx92, we will only disable proxy configurations provided by
  * extensions.  Prior to 92, we could not definitively identify extensions from
  * the proxyInfo instance.
- * 
+ *
  * If we've disabled proxies, we continue to watch the requests for failures in
  * "direct" connection mode.  If we continue to fail with direct connections,
  * we fall back to allowing proxies again.
@@ -98,7 +105,14 @@ const ProxyMonitor = {
 
   newDirectProxyInfo(failover = null) {
     return ProxyService.newProxyInfo(
-      PROXY_DIRECT, "", 0, "", "", 0, 0, failover
+      PROXY_DIRECT,
+      "",
+      0,
+      "",
+      "",
+      0,
+      0,
+      failover
     );
   },
 
@@ -116,16 +130,18 @@ const ProxyMonitor = {
         return;
       }
 
-      // We monitor for successful connections which in some cases may 
+      // We monitor for successful connections which in some cases may
       // re-enable a prior failed proxy configuration.
       let wrapper = ChannelWrapper.get(channel);
       wrapper.addEventListener("start", this);
 
       if (this.tooManyFailures()) {
         log(`too many proxy config failures, prepend direct rid ${wrapper.id}`);
-        // A lot of failures are happening.  Try direct first, but failover to 
+        // A lot of failures are happening.  Try direct first, but failover to
         // any non-extension proxies "just in case".
-        proxyInfo = this.newDirectProxyInfo(await this.pruneExtensions(defaultProxyInfo));
+        proxyInfo = this.newDirectProxyInfo(
+          await this.pruneExtensions(defaultProxyInfo)
+        );
         return;
       }
       this.dumpProxies(proxyInfo, `starting proxyInfo rid ${wrapper.id}`);
@@ -135,12 +151,14 @@ const ProxyMonitor = {
         // All current proxies are disabled due to prior failures.  Try direct
         // first, but failover to any non-extension proxies "just in case".
         log(`all proxies disabled, prepend direct`);
-        proxyInfo = this.newDirectProxyInfo(await this.pruneExtensions(defaultProxyInfo));
+        proxyInfo = this.newDirectProxyInfo(
+          await this.pruneExtensions(defaultProxyInfo)
+        );
         return;
       }
 
-      // If we are not attempting a direct bypass we want to monitor for non-connection errors 
-      // such as invalid proxy servers.  
+      // If we are not attempting a direct bypass we want to monitor for
+      // non-connection errors such as invalid proxy servers.
       wrapper.addEventListener("error", this);
 
       // A little debug output
@@ -156,16 +174,17 @@ const ProxyMonitor = {
       return null;
     }
     // Re-link the proxy chain.
-    // failoverProxy cannot be set to undefined or null, we fixup the last failover
-    // with a direct failover if necessary.
+    // failoverProxy cannot be set to undefined or null, we fixup the last
+    // failover with a direct failover if necessary.
     for (let i = 0; i < proxies.length - 2; i++) {
       proxies[i].failoverProxy = proxies[i + 1];
     }
     let top = proxies[0];
     let last = proxies.pop();
     // Ensure the last proxy is not linked to something we removed.  This
-    // catches connection failures such as those to non-existant or non-http ports.
-    // The "error" handler added above catches http connections that are not proxy servers.
+    // catches connection failures such as those to non-existant or non-http
+    // ports.  The "error" handler added above catches http connections that
+    // are not proxy servers.
     if (last.failoverProxy || last.type != PROXY_DIRECT) {
       last.failoverProxy = this.newDirectProxyInfo();
     }
@@ -189,10 +208,10 @@ const ProxyMonitor = {
     }
     return this.relinkProxyInfoChain(enabledProxies);
   },
-  
+
   // Verify the entire proxy failover chain is clean.  There may be multiple
-  // sources for proxyInfo in the chain, so we remove any disabled entries
-  // and continue to use configurations that have not yet failed.
+  // sources for proxyInfo in the chain, so we remove any disabled entries and
+  // continue to use configurations that have not yet failed.
   pruneProxyInfo(proxyInfo) {
     let enabledProxies = [];
     let pi = proxyInfo;
@@ -233,8 +252,8 @@ const ProxyMonitor = {
       return false;
     }
 
-    // From 92 forward, if an extension has one disabled PI, we disable all PIs from 
-    // that extension for the DISABLE_HOURS perid.
+    // From 92 forward, if an extension has one disabled PI, we disable all PIs
+    // from that extension for the DISABLE_HOURS perid.
     let extTime = proxyInfo.sourceId && this.extensions.get(proxyInfo.sourceId);
     if (extTime && hoursSince(extTime) <= DISABLE_HOURS) {
       return true;
@@ -245,8 +264,8 @@ const ProxyMonitor = {
       return false;
     }
 
-    // We keep a proxy config disabled for DISABLE_HOURS to give
-    // our daily update checks time to complete again.
+    // We keep a proxy config disabled for DISABLE_HOURS to give our daily
+    // update checks time to complete again.
     if (hoursSince(err.time) >= DISABLE_HOURS) {
       this.errors.delete(key);
       this.logProxySource("timeout", proxyInfo);
@@ -262,30 +281,35 @@ const ProxyMonitor = {
       return;
     }
     let { type, host, port } = proxyInfo;
+    // eslint-disable-next-line consistent-return
     return `${type}:${host}:${port}`;
   },
 
-  // If proxy.settings is used to change the proxy, an extension will
-  // be "in control".  This returns the id of that extension.
+  // If proxy.settings is used to change the proxy, an extension will be "in
+  // control".  This returns the id of that extension.
   async getControllingExtension() {
     // Is this proxied by an extension that set proxy prefs?
-    let setting = await ExtensionPreferencesManager.getSetting("proxy.settings");
+    let setting = await ExtensionPreferencesManager.getSetting(
+      "proxy.settings"
+    );
     return setting?.id;
   },
 
   async getProxySource(proxyInfo) {
-      // sourceId is set when using proxy.onRequest
+    // sourceId is set when using proxy.onRequest
     if (proxyInfo.sourceId) {
       return {
         source: proxyInfo.sourceId,
-        type: "api"
+        type: "api",
       };
     }
     let type = PROXY_CONFIG_TYPES[ProxyService.proxyConfigType] || "unknown";
 
     // If we have a policy it will have set the prefs.
     if (Services.policies.status === Services.policies.ACTIVE) {
-      let policies = Services.policies.getActivePolicies()?.filter(p => p.Proxy);
+      let policies = Services.policies
+        .getActivePolicies()
+        ?.filter(p => p.Proxy);
       if (policies?.length) {
         return {
           source: "policy",
@@ -308,13 +332,7 @@ const ProxyMonitor = {
 
   recordEvent(method, obj, type = null, source = {}) {
     try {
-      Services.telemetry.recordEvent(
-        "proxyMonitor",
-        method,
-        obj,
-        type,
-        source
-      );
+      Services.telemetry.recordEvent("proxyMonitor", method, obj, type, source);
       log(`event: ${method} ${obj} ${type} ${JSON.stringify(source)}`);
     } catch (err) {
       // If the telemetry throws just log the error so it doesn't break any
@@ -325,7 +343,7 @@ const ProxyMonitor = {
 
   timeoutEntries() {
     // remove old entries
-    for (let [k ,err] of this.errors) {
+    for (let [k, err] of this.errors) {
       if (hoursSince(err.time) >= DISABLE_HOURS) {
         this.errors.delete(k);
         this.recordEvent("timeout", "proxyInfo");
@@ -351,7 +369,8 @@ const ProxyMonitor = {
     // From 92 forward, we disable all extension provided proxies if one fails
     let extensionId;
     if (CHECK_EXTENSION_ONLY) {
-      extensionId = proxyInfo.sourceId || (await this.getControllingExtension());
+      extensionId =
+        proxyInfo.sourceId || (await this.getControllingExtension());
     }
 
     this.timeoutEntries();
@@ -361,7 +380,9 @@ const ProxyMonitor = {
     if (extensionId) {
       this.extensions.set(extensionId, err.time);
       log(`all proxy configuration from extension ${extensionId} disabled`);
-      this.recordEvent("start", "proxyBypass", "extension", { source: extensionId });
+      this.recordEvent("start", "proxyBypass", "extension", {
+        source: extensionId,
+      });
     }
     this.logProxySource("disabled", proxyInfo);
     // If lots of proxies have failed, we
@@ -387,12 +408,14 @@ const ProxyMonitor = {
     if (!CHECK_EXTENSION_ONLY) {
       return;
     }
-    let extensionId = proxyInfo.sourceId || (await this.getControllingExtension());
+    let extensionId =
+      proxyInfo.sourceId || (await this.getControllingExtension());
     if (!extensionId) {
       return;
     }
     // Only delete if no err entries with the id exists.
-    for (let [k ,err] of this.errors) {
+    // eslint-disable-next-line no-unused-vars
+    for (let [k, err] of this.errors) {
       if (err.extensionId == extensionId) {
         return;
       }
@@ -412,7 +435,7 @@ const ProxyMonitor = {
 
     const wpl = Ci.nsIWebProgressListener;
     const state = securityInfo.securityState;
-    return !!(state &  wpl.STATE_IS_SECURE);
+    return !!(state & wpl.STATE_IS_SECURE);
   },
 
   handleEvent(event) {
@@ -422,9 +445,8 @@ const ProxyMonitor = {
       log(`got ${event.type} event but not a proxied channel`);
       return;
     }
-    // If this is an http request ignore it, it is too easily
-    // tampered with.  Fortunately its use is limited, potentially
-    // only captive portal.
+    // If this is an http request ignore it, it is too easily tampered with.
+    // Fortunately its use is limited, potentially only captive portal.
     if (wrapper.finalURL.startsWith("http:")) {
       return;
     }
@@ -432,7 +454,9 @@ const ProxyMonitor = {
     // The tls handshake must succeed to re-enable a request.
     let tlsIsSecure = this.tlsCheck(channel);
 
-    log(`request event ${event.type} rid ${wrapper.id} status ${wrapper.statusCode} tls ${tlsIsSecure} for ${channel.URI.spec}`);
+    log(
+      `request event ${event.type} rid ${wrapper.id} status ${wrapper.statusCode} tls ${tlsIsSecure} for ${channel.URI.spec}`
+    );
     let status = wrapper.statusCode;
     switch (event.type) {
       case "error":
@@ -473,7 +497,12 @@ const ProxyMonitor = {
       failovers = JSON.parse(failovers);
       this.disabledTime = failovers.disabledTime;
       this.errors = new Map(failovers.errors);
-      this.extensions = new Map(failovers.errors.filter(e => e[1].extensionId).sort((a, b) => a[1].time - b[1].time).map(e => [e[1].extensionId, e[1].time]));
+      this.extensions = new Map(
+        failovers.errors
+          .filter(e => e[1].extensionId)
+          .sort((a, b) => a[1].time - b[1].time)
+          .map(e => [e[1].extensionId, e[1].time])
+      );
     } else {
       this.disabledTime = 0;
       this.errors = new Map();
@@ -482,11 +511,9 @@ const ProxyMonitor = {
   },
 
   startup() {
-    // Register filter with a very high position, this will sort to the last filter called.
-    ProxyService.registerChannelFilter(
-      ProxyMonitor,
-      Number.MAX_SAFE_INTEGER
-    );
+    // Register filter with a very high position, this will sort to the last
+    // filter called.
+    ProxyService.registerChannelFilter(ProxyMonitor, Number.MAX_SAFE_INTEGER);
     this.restore();
     log("started");
   },
@@ -495,8 +522,8 @@ const ProxyMonitor = {
     ProxyService.unregisterFilter(ProxyMonitor);
     this.store();
     log("stopped");
-  }
-}
+  },
+};
 
 /**
  * Listen for changes in addons and pref to start or stop the ProxyMonitor.
@@ -552,9 +579,11 @@ const monitor = {
 
   hasProxyExtension(ignore) {
     for (let policy of WebExtensionPolicy.getActiveExtensions()) {
-      if (policy.id != ignore 
-          && !policy.extension?.isAppProvided 
-          && policy.hasPermission("proxy")) {
+      if (
+        policy.id != ignore &&
+        !policy.extension?.isAppProvided &&
+        policy.hasPermission("proxy")
+      ) {
         return true;
       }
     }
@@ -565,9 +594,11 @@ const monitor = {
     switch (kind) {
       case "startup": {
         let [extension] = args;
-        if (!monitor.running 
-            && !extension.isAppProvided 
-            && extension.hasPermission("proxy")) {
+        if (
+          !monitor.running &&
+          !extension.isAppProvided &&
+          extension.hasPermission("proxy")
+        ) {
           monitor.startMonitors();
         }
         break;
@@ -579,9 +610,11 @@ const monitor = {
         }
         let [extension] = args;
         // WebExtensionPolicy is still active, pass the id to ignore it.
-        if (monitor.running 
-            && !extension.isAppProvided 
-            && !monitor.hasProxyExtension(extension.id)) {
+        if (
+          monitor.running &&
+          !extension.isAppProvided &&
+          !monitor.hasProxyExtension(extension.id)
+        ) {
           monitor.stopMonitors();
         }
         break;
@@ -609,10 +642,7 @@ this.failover = class extends ExtensionAPI {
     Services.telemetry.registerEvents("proxyMonitor", {
       proxyMonitor: {
         methods: ["enabled", "disabled", "start", "timeout"],
-        objects: [
-          "proxyInfo",
-          "proxyBypass"
-        ],
+        objects: ["proxyInfo", "proxyBypass"],
         extra_keys: ["source"],
         record_on_release: true,
       },

--- a/extension/api.js
+++ b/extension/api.js
@@ -4,9 +4,11 @@
 
 "use strict";
 
-/* globals ExtensionAPI, Services, XPCOMUtils, WebExtensionPolicy */
+/* globals ExtensionAPI, XPCOMUtils */
 
+const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 XPCOMUtils.defineLazyGlobalGetters(this, ["ChannelWrapper"]);
+const { WebExtensionPolicy } = Cu.getGlobalForObject(Services);
 
 XPCOMUtils.defineLazyServiceGetter(
   this,

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,11 +4,10 @@
   "applications": {
     "gecko": {
       "id": "proxy-failover@mozilla.com",
-      "strict_min_version": "78.0",
-      "strict_max_version": "100.0"
+      "strict_min_version": "78.0"
     }
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Direct Failover for system requests.",
   "experiment_apis": {
     "failover": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,7 +4,8 @@
   "applications": {
     "gecko": {
       "id": "proxy-failover@mozilla.com",
-      "strict_min_version": "78.0"
+      "strict_min_version": "78.0",
+      "strict_max_version": "100.0"
     }
   },
   "version": "1.0.2",


### PR DESCRIPTION
Fixes https://github.com/mozilla-extensions/proxy-monitor/issues/15

---

There is no actual code change other than some imports removed because the symbols already exist. The code looks different because Prettier was applied, though.