### PR TITLE
Mark repository as public in TaskCluster config

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -6,7 +6,7 @@ policy:
 tasks:
     - $let:
           # XXX Set to `true` for private repos
-          privateRepo: true
+          privateRepo: false
           # XXX Use
           # `system` for system add-on,
           # `privileged` for AMO or self-hosted privileged add-on,


### PR DESCRIPTION
I repurposed this PR since the work on the linter has been merged upstream (in xpi-template).